### PR TITLE
Switch yq devDeps cmd from allowlist to denylist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 # Copy the content of the project to the machine
 COPY . .
-RUN yq --inplace --output-format=json '(.dependencies = .dependencies * (.devDependencies | to_entries | map(select(.key | test("^(jest|@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|@types/dotenv-safe|@types/node|@types/react|@types/react-dom|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries)) | (.devDependencies = {})' package.json
+RUN yq --inplace --output-format=json '(.dependencies = .dependencies * (.devDependencies | to_entries | map(select(.key | test("^(@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|@types/dotenv-safe|@types/node|@types/react|@types/react-dom|jest|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries)) | (.devDependencies = {})' package.json
 RUN pnpm install
 RUN pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 # Copy the content of the project to the machine
 COPY . .
-RUN yq --inplace --output-format=json '(.dependencies = .dependencies * (.devDependencies | to_entries | map(select(.key | test("^(typescript|@types/*|eslint-config-upleveled)$"))) | from_entries)) | (.devDependencies = {})' package.json
+RUN yq --inplace --output-format=json '(.dependencies = .dependencies * (.devDependencies | to_entries | map(select(.key | test("^(jest|@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|@types/dotenv-safe|@types/node|@types/react|@types/react-dom|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries)) | (.devDependencies = {})' package.json
 RUN pnpm install
 RUN pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 # Copy the content of the project to the machine
 COPY . .
-RUN yq --inplace --output-format=json '(.dependencies = .dependencies * (.devDependencies | to_entries | map(select(.key | test("^(@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|@types/dotenv-safe|@types/node|@types/react|@types/react-dom|jest|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries)) | (.devDependencies = {})' package.json
+RUN yq --inplace --output-format=json '(.devDependencies = (.devDependencies | to_entries | map(select(.key | test("^(@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|@types/dotenv-safe|@types/node|@types/react|@types/react-dom|jest|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries))' package.json
 RUN pnpm install
 RUN pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 # Copy the content of the project to the machine
 COPY . .
-RUN yq --inplace --output-format=json '(.devDependencies = (.devDependencies | to_entries | map(select(.key | test("^(@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|@types/dotenv-safe|@types/node|@types/react|@types/react-dom|jest|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries))' package.json
+RUN yq --inplace --output-format=json '(.devDependencies = (.devDependencies | to_entries | map(select(.key | test("^(@jest/globals|@playwright/test|@ts-safeql/eslint-plugin|jest|jest-environment-jsdom|libpg-query|prettier|prettier-plugin-embed|prettier-plugin-sql|stylelint|stylelint-config-upleveled)$") | not)) | from_entries))' package.json
 RUN pnpm install
 RUN pnpm build
 


### PR DESCRIPTION
Closes https://github.com/upleveled/courses/issues/2519

When initializing a Next.js project with TailwindCSS, TailwindCSS gets added to the `devDependencies`. This can lead to issues when deploying the project. 

```
8.509 An error occurred in `next/font`.
8.509 
8.509 Error: Cannot find module 'tailwindcss'
```

To fix this issue, this PR switches the `yq` command from using an allowlist approach to a denylist approach. This means we filter out the `devDepdendencies` that we are not using for production. 