### PR TITLE
Test Playwright on Windows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,19 +71,7 @@ jobs:
       - name: Build Next.js app
         run: pnpm build
 
-      # Cache and install Playwright browser binaries, modified version of:
-      # https://github.com/microsoft/playwright/issues/7249#issuecomment-1154603556
-      # https://github.com/microsoft/playwright/issues/7249#issuecomment-1385567519
-      # https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
-      - name: Get installed Playwright version for cache key
-        run: echo "PLAYWRIGHT_VERSION=$(yq eval '.version' --output-format=yaml ./node_modules/@playwright/test/package.json)" >> $GITHUB_ENV
-      - name: Cache Playwright browser binaries
-        uses: actions/cache@v4
-        id: playwright-browser-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: Install Playwright browsers only on cache miss
         run: pnpm playwright install --with-deps chromium
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,31 +3,62 @@ on: push
 
 jobs:
   ci:
-    name: Jest Unit Tests, Type Checking, Linting, Playwright End to End Tests
-    runs-on: ubuntu-latest # or macos-latest, windows-latest
-    timeout-minutes: 30
-    # TODO: Update environment variables with your own database credentials
+    name: CI
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+    timeout-minutes: 15
     env:
       PGHOST: localhost
-      PGDATABASE: next_js_example_spring_2024
-      PGUSERNAME: next_js_example_spring_2024
-      PGPASSWORD: next_js_example_spring_2024
+      PGDATABASE: preflight_test_project_next_js_passing
+      PGUSERNAME: preflight_test_project_next_js_passing
+      PGPASSWORD: preflight_test_project_next_js_passing
     steps:
-      - name: Start preinstalled PostgreSQL on Ubuntu
+      # Create PostgreSQL databases on Windows, macOS and Linux
+      # https://github.com/karlhorky/github-tricks/#github-actions-create-postgresql-databases-on-windows-macos-and-linux
+      - name: Add PostgreSQL binaries to PATH
+        shell: bash
         run: |
-          sudo systemctl start postgresql.service
-          pg_isready
-      - name: Create database user
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "$PGBIN" >> $GITHUB_PATH
+          fi
+      - name: Start preinstalled PostgreSQL
+        shell: bash
         run: |
-          sudo -u postgres psql --command="CREATE USER $PGUSERNAME PASSWORD '$PGPASSWORD'" --command="\du"
-      - name: Create database and allow user
-        run: |
-          sudo -u postgres createdb --owner=$PGUSERNAME $PGDATABASE
+          echo "Initializing database cluster..."
+
+          # Convert backslashes to forward slashes in RUNNER_TEMP for Windows Git Bash
+          export PGHOST="${RUNNER_TEMP//\\//}/postgres"
+          export PGDATA="$PGHOST/pgdata"
+          mkdir -p "$PGDATA"
+
+          # initdb requires file for password in non-interactive mode
+          export PWFILE="$RUNNER_TEMP/pwfile"
+          echo "postgres" > "$PWFILE"
+          initdb --pgdata="$PGDATA" --username="postgres" --pwfile="$PWFILE"
+
+          echo "Starting PostgreSQL..."
+          echo "unix_socket_directories = '$PGHOST'" >> "$PGDATA/postgresql.conf"
+          pg_ctl start
+
+          echo "Creating user..."
+          psql --host "$PGHOST" --username="postgres" --dbname="postgres" --command="CREATE USER $PGUSERNAME PASSWORD '$PGPASSWORD'" --command="\du"
+
+          echo "Creating database..."
+          createdb --owner="$PGUSERNAME" --username="postgres" "$PGDATABASE"
+
+      # Avoid CRLF in Windows tests, which cause problems with Prettier:
+      # https://github.com/upleveled/preflight/runs/1824397400
+      #
+      # Suggested here: https://github.com/actions/checkout/issues/250#issuecomment-635267458
+      # Example repo: https://github.com/ghdl/ghdl/blob/aa63b5efcd2be66acc26443032df2b251e4b1a7a/.github/workflows/Test.yml#L230-L232
+      - name: Use LF instead of CRLF for clone
+        run: git config --global core.autocrlf input
+
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
 
-      # Use the official setup-node action (sets up Node.js):
-      # https://github.com/actions/setup-node
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -36,18 +67,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-      - name: Jest unit tests
-        run: pnpm jest
-      - name: Run database migrations
-        run: pnpm migrate up
-      - name: Build Next.js app (types needed for TSC and ESLint)
+
+      - run: pnpm migrate up
+
+      # Also generates next-env.d.ts, required for tsc
+      - name: Build Next.js app
         run: pnpm build
-      - name: Check TypeScript Types
-        run: pnpm tsc
-      - name: Lint with ESLint
-        run: pnpm eslint . --max-warnings 0
-      - name: Lint with Stylelint
-        run: pnpm stylelint '**/*.{css,scss,less,js,tsx}'
 
       # Cache and install Playwright browser binaries, modified version of:
       # https://github.com/microsoft/playwright/issues/7249#issuecomment-1154603556
@@ -73,15 +98,3 @@ jobs:
         with:
           name: playwright-screenshots-videos
           path: playwright/test-results/
-  cd:
-    name: Deploy to Fly.io
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: ci
-    if: github.ref == 'refs/heads/main'
-    env:
-      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     timeout-minutes: 15
     env:
       PGHOST: localhost
@@ -17,11 +17,16 @@ jobs:
     steps:
       # Create PostgreSQL databases on Windows, macOS and Linux
       # https://github.com/karlhorky/github-tricks/#github-actions-create-postgresql-databases-on-windows-macos-and-linux
+      - name: Install PostgreSQL on macOS
+        if: runner.os == 'macOS'
+        run: brew install postgresql
       - name: Add PostgreSQL binaries to PATH
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             echo "$PGBIN" >> $GITHUB_PATH
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+            echo "$(pg_config --bindir)" >> $GITHUB_PATH
           fi
       - name: Start preinstalled PostgreSQL
         shell: bash
@@ -47,14 +52,6 @@ jobs:
 
           echo "Creating database..."
           createdb --owner="$PGUSERNAME" --username="postgres" "$PGDATABASE"
-
-      # Avoid CRLF in Windows tests, which cause problems with Prettier:
-      # https://github.com/upleveled/preflight/runs/1824397400
-      #
-      # Suggested here: https://github.com/actions/checkout/issues/250#issuecomment-635267458
-      # Example repo: https://github.com/ghdl/ghdl/blob/aa63b5efcd2be66acc26443032df2b251e4b1a7a/.github/workflows/Test.yml#L230-L232
-      - name: Use LF instead of CRLF for clone
-        run: git config --global core.autocrlf input
 
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-upleveled": "^8.2.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "libpg-query": "^15.2.0",
+    "libpg-query": "^16.2.0",
     "prettier": "^3.2.5",
     "prettier-plugin-embed": "^0.4.15",
     "prettier-plugin-sql": "^0.18.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { PlaywrightTestConfig } from '@playwright/test';
 // Config file docs: https://playwright.dev/docs/test-configuration
 const config: PlaywrightTestConfig = {
   webServer: {
-    command: './node_modules/.bin/next start',
+    command: '"./node_modules/.bin/next" start',
     port: 3000,
     stdout: 'pipe',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 1.44.1
       '@ts-safeql/eslint-plugin':
         specifier: ^3.3.0
-        version: 3.3.0(eslint@9.3.0)(libpg-query@15.2.0(encoding@0.1.13))(typescript@5.4.5)
+        version: 3.3.0(eslint@9.3.0)(libpg-query@16.2.0(encoding@0.1.13))(typescript@5.4.5)
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2
@@ -82,8 +82,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       libpg-query:
-        specifier: ^15.2.0
-        version: 15.2.0(encoding@0.1.13)
+        specifier: ^16.2.0
+        version: 16.2.0(encoding@0.1.13)
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -791,9 +791,6 @@ packages:
   '@npmcli/fs@3.1.1':
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  '@pgsql/types@15.0.2':
-    resolution: {integrity: sha512-K3gtnbqbSUuUVmPm143qx5Gy2EmKuooshV95yMD48EUQ1256sgZBriEfY61OWJnlzdREdqHTIOxQqpZAb7XdZg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2560,8 +2557,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libpg-query@15.2.0:
-    resolution: {integrity: sha512-fBi14tsU3/ahtfU0C+/tvmtlt0EJM6kXe0Dl4/cSbiNmJ3IwLIuk3lawwiK5ByXU4sXwyAzbkvSl26jVXzYuaA==}
+  libpg-query@16.2.0:
+    resolution: {integrity: sha512-quviVdvqHPxQNhHKOHzc4XhIF/29TAwYPTfnNralWdWWORBCFI+m70cN3FeOEdTn/ndp83PBnok3+Tt7ofUjnw==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -4501,8 +4498,6 @@ snapshots:
     dependencies:
       semver: 7.6.2
 
-  '@pgsql/types@15.0.2': {}
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4528,12 +4523,12 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@ts-safeql/eslint-plugin@3.3.0(eslint@9.3.0)(libpg-query@15.2.0(encoding@0.1.13))(typescript@5.4.5)':
+  '@ts-safeql/eslint-plugin@3.3.0(eslint@9.3.0)(libpg-query@16.2.0(encoding@0.1.13))(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/utils': 7.11.0(eslint@9.3.0)(typescript@5.4.5)
       chokidar: 3.6.0
       fp-ts: 2.16.6
-      libpg-query: 15.2.0(encoding@0.1.13)
+      libpg-query: 16.2.0(encoding@0.1.13)
       pg-connection-string: 2.5.0
       postgres: 3.4.4
       synckit: 0.9.0
@@ -6779,11 +6774,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libpg-query@15.2.0(encoding@0.1.13):
+  libpg-query@16.2.0(encoding@0.1.13):
     dependencies:
       '@emnapi/runtime': 0.43.1
       '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
-      '@pgsql/types': 15.0.2
       node-addon-api: 7.1.0
       node-gyp: 10.1.0
     transitivePeerDependencies:


### PR DESCRIPTION
On Windows, `pnpm playwright test` fails with the following `webServer` configuration:

```bash
$ pnpm playwright test
[WebServer] '.' is not recognized as an internal or external command, operable program or batch file. Error: Process from config.webServer was not able to start. Exit code: 1
```

```js
  webServer: {
    command: './node_modules/.bin/next start',
    port: 3000,
    stdout: 'pipe',
  },
```

This is probably because of the `./` in the `webServer.command` (should probably be opened as a Playwright bug - some Stack Overflow links if helpful: 1) ['.' is not recognized as an internal or external command windows 10](https://stackoverflow.com/questions/48605192/is-not-recognized-as-an-internal-or-external-command-windows-10) 2) [How to fix '.' is not an internal or external command error](https://stackoverflow.com/questions/20765337/how-to-fix-is-not-an-internal-or-external-command-error))

Adding quotes around the binary path works on Windows, macOS, Linux:

```js
  webServer: {
    command: '"./node_modules/.bin/next" start',
    port: 3000,
    stdout: 'pipe',
  },
```