### PR TITLE
Add generate password step to Linux system user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Quit `psql` using the following command:
 \q
 ```
 
-On Linux, it is [best practice to create an operating system user for each database](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_using_database_servers/using-postgresql_configuring-and-using-database-servers#con_postgresql-users_using-postgresql), to ensure that the operating system user can only access the single database and no other system resources. A different password is needed on Linux, because [passwords of operating system users cannot contain the user name](https://github.com/upleveled/system-setup/issues/74). First, generate a random password and copy it:
+On Linux, it is [best practice to create an operating system user for each database](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_using_database_servers/using-postgresql_configuring-and-using-database-servers#con_postgresql-users_using-postgresql), to ensure that the operating system user can only access the single database and no other system resources. A different password is needed on Linux because [passwords of operating system users cannot contain the user name](https://github.com/upleveled/system-setup/issues/74). First, generate a random password and copy it:
 
 ```bash
 openssl rand -hex 16

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Quit `psql` using the following command:
 \q
 ```
 
-On Linux, you will also need to create a Linux system user with a name matching the user name you used in the database. Generate a random password for the user:
+On Linux, it is [best practice to create an operating system user for each database](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_using_database_servers/using-postgresql_configuring-and-using-database-servers#con_postgresql-users_using-postgresql), to ensure that the operating system user can only access the single database and no other system resources. A different password is needed on Linux, because [passwords of operating system users cannot contain the user name](https://github.com/upleveled/system-setup/issues/74). First, generate a random password and copy it:
 
 ```bash
 openssl rand -hex 16
 ```
 
-Copy and save the generated password and create the user. It will prompt you to create a password for the user - choose the random generated password.
+Then create the user, using the database user name from the previous section above. When you are prompted to create a password for the user, paste in the generated password.
 
 ```bash
 sudo adduser <user name>

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Quit `psql` using the following command:
 \q
 ```
 
-On Linux, you will also need to create a Linux system user with a name matching the user name you used in the database. It will prompt you to create a password for the user - choose the same password as for the database above.
+On Linux, you will also need to create a Linux system user with a name matching the user name you used in the database. Generate a random password for the user:
 
 ```bash
-sudo adduser <user name>
+openssl rand -hex 16
 ```
+
+Copy and save the generated password and create the user. It will prompt you to create a password for the user - choose the random generated password.
 
 Once you're ready to use the new user, reconnect using the following command.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ openssl rand -hex 16
 
 Copy and save the generated password and create the user. It will prompt you to create a password for the user - choose the random generated password.
 
+```bash
+sudo adduser <user name>
+```
+
 Once you're ready to use the new user, reconnect using the following command.
 
 **Windows and macOS:**


### PR DESCRIPTION
Related to https://github.com/upleveled/courses/pull/2565
Issue https://github.com/upleveled/system-setup/issues/74

This PR updates the Readme to improve the process for creating a Linux system user when setting up a new PostgreSQL database. Previously, the guide advised students to use the same password as the username, which triggers the following warning:

```
BAD PASSWORD: The password contains the user name in some form
```

To avoid this warning, the updated instructions now guide users to generate a strong random password using OpenSSL. This change ensures that the password is not the same as the username.

