### PR TITLE
Switch globalThis var to local let var in IIFE closure

### DIFF
--- a/database/connect.ts
+++ b/database/connect.ts
@@ -6,37 +6,26 @@ import { setEnvironmentVariables } from '../util/config';
 
 setEnvironmentVariables();
 
-declare module globalThis {
-  let postgresSqlClient: Sql;
-}
-
 // Connect only once to the database
 // https://github.com/vercel/next.js/issues/7811#issuecomment-715259370
-function connectOneTimeToDatabase() {
-  if (!('postgresSqlClient' in globalThis)) {
-    globalThis.postgresSqlClient = postgres(postgresConfig);
-  }
+const connectOneTimeToDatabase = (() => {
+  let postgresSqlClient: Sql;
 
-  // Workaround to force Next.js Dynamic Rendering on every database query:
-  //
-  // Wrap sql`` tagged template function to call `noStore()` from
-  // next/cache before each database query. `noStore()` is a
-  // Next.js Dynamic Function, which causes the page to use
-  // Dynamic Rendering
-  //
-  // https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic-rendering
-  //
-  // Ideally there would something built into Next.js for this,
-  // which has been requested here:
-  //
-  // https://github.com/vercel/next.js/discussions/50695
-  return ((
-    ...sqlParameters: Parameters<typeof globalThis.postgresSqlClient>
-  ) => {
-    noStore();
-    return globalThis.postgresSqlClient(...sqlParameters);
-  }) as typeof globalThis.postgresSqlClient;
-}
+  return function connectOneTimeToDatabase() {
+    if (!postgresSqlClient) {
+      postgresSqlClient = postgres(postgresConfig);
+    }
+
+    // Workaround to force Next.js Dynamic Rendering on every database query
+    // https://github.com/vercel/next.js/discussions/50695
+    return ((
+      ...sqlParameters: Parameters<typeof postgresSqlClient>
+    ) => {
+      noStore();
+      return postgresSqlClient(...sqlParameters);
+    }) as typeof postgresSqlClient;
+  };
+})();
 
 export const sql = connectOneTimeToDatabase();
 

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -11,8 +11,8 @@ setEnvironmentVariables();
 const connectOneTimeToDatabase = (() => {
   let postgresSqlClient: Sql;
 
-  return function connectOneTimeToDatabase() {
-    if (!postgresSqlClient) {
+  return () => {
+    if (typeof postgresSqlClient === 'undefined') {
       postgresSqlClient = postgres(postgresConfig);
     }
 

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -16,7 +16,7 @@ const connectOneTimeToDatabase = (() => {
       postgresSqlClient = postgres(postgresConfig);
     }
 
-    // Workaround to force Next.js Dynamic Rendering on every database query
+    // Workaround to force Next.js Dynamic Rendering on every database query:
     //
     // Wrap sql`` tagged template function to call `noStore()` from
     // next/cache before each database query. `noStore()` is a

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -17,6 +17,17 @@ const connectOneTimeToDatabase = (() => {
     }
 
     // Workaround to force Next.js Dynamic Rendering on every database query
+    //
+    // Wrap sql`` tagged template function to call `noStore()` from
+    // next/cache before each database query. `noStore()` is a
+    // Next.js Dynamic Function, which causes the page to use
+    // Dynamic Rendering
+    //
+    // https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic-rendering
+    //
+    // Ideally there would something built into Next.js for this,
+    // which has been requested here:
+    //
     // https://github.com/vercel/next.js/discussions/50695
     return ((
       ...sqlParameters: Parameters<typeof postgresSqlClient>


### PR DESCRIPTION
Considering dropping usage of `globalThis` in favor of a local `let` variable in an IIFE closure, thanks to the motivation of this discussion:

- https://github.com/typescript-eslint/typescript-eslint/issues/7941#issuecomment-2309799234

TODO:

- [ ] Confirm that this approach works with the development server
- [ ] Confirm that this approach works with React Native + Expo https://github.com/upleveled/expo-example-spring-2024-atvie/pull/4

If we go ahead with this approach, we can probably re-enable the `@typescript-eslint/no-namespace` rule in `eslint-config-upleveled`:

- https://github.com/upleveled/eslint-config-upleveled/issues/402